### PR TITLE
Add Canadian Shield, amend Quad9 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ On iOS, after installation, go to system **Settings => General => Profile**, sel
 
 - [🇷🇺 AdGuard](https://adguard.com/en/adguard-dns/overview.html#instruction)
 - [🇨🇳 Alibaba](https://www.alidns.com/faqs/#dns-safe)
+- [🇨🇦 Canadian Shield](https://www.cira.ca/cybersecurity-services/canadian-shield) - Operated by the Canadian Internet Registration Authority (CIRA)
 - [🇺🇸 Cloudflare](https://developers.cloudflare.com/1.1.1.1/dns-over-https)
 - 🇨🇳 DNSPod
 - [🇺🇸 Google](https://developers.google.com/speed/public-dns/docs/secure-transports)
 - [🇺🇸 OpenDNS](https://support.opendns.com/hc/en-us/articles/360038086532)
-- [🇺🇸 Quad9](https://www.quad9.net/doh-quad9-dns-servers/) — no filtering. Operated by CleanerDNS, Inc. 
+- [🇺🇸 Quad9](https://www.quad9.net/doh-quad9-dns-servers/) — Filters malicious domains. Operated by CleanerDNS, Inc. 
 - [🇸🇬🇺🇸 Tiar.app](https://doh.tiar.app) — "Privacy-first DNS provider". Filters some domains. Server is located in SG, hosted on Digital Ocean
 
 To verify resolver IPs and hostnames, compare mobileconfig files to their documentation URLs. Internal workings of the profiles are described on [developer.apple.com](https://developer.apple.com/documentation/devicemanagement/dnssettings).

--- a/canadianshield-family-https.mobileconfig
+++ b/canadianshield-family-https.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>2620:10A:80BB::30</string>
+					<string>2620:10A:80BC::30</string>
+					<string>149.112.121.30</string>
+					<string>149.112.122.30</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://family.canadianshield.cira.ca/dns-query</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use Canadian Shield Encrypted DNS over HTTPS</string>
+			<key>PayloadDisplayName</key>
+			<string>Canadian Shield DNS over HTTPS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the Canadian Shield DNS to Big Sur and iOS 14 based systems</string>
+	<key>PayloadDisplayName</key>
+	<string>Canadian Shield DNS over HTTPS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>32E01895-86AB-40AE-ACD2-4460D584EA35</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/canadianshield-family-tls.mobileconfig
+++ b/canadianshield-family-tls.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>TLS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>2620:10A:80BB::30</string>
+					<string>2620:10A:80BC::30</string>
+					<string>149.112.121.30</string>
+					<string>149.112.122.30</string>
+				</array>
+				<key>ServerName</key>
+				<string>family.canadianshield.cira.ca</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use Canadian Shield Encrypted DNS over TLS</string>
+			<key>PayloadDisplayName</key>
+			<string>Canadian Shield DNS over TLS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the Canadian Shield DNS to Big Sur and iOS 14 based systems</string>
+	<key>PayloadDisplayName</key>
+	<string>Canadian Shield DNS over TLS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>32E01895-86AB-40AE-ACD2-4460D584EA35</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/canadianshield-private-https.mobileconfig
+++ b/canadianshield-private-https.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>2620:10A:80BB::10</string>
+					<string>2620:10A:80BC::10</string>
+					<string>149.112.121.10</string>
+					<string>149.112.122.10</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://private.canadianshield.cira.ca/dns-query</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use Canadian Shield Encrypted DNS over HTTPS</string>
+			<key>PayloadDisplayName</key>
+			<string>Canadian Shield DNS over HTTPS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the Canadian Shield DNS to Big Sur and iOS 14 based systems</string>
+	<key>PayloadDisplayName</key>
+	<string>Canadian Shield DNS over HTTPS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>32E01895-86AB-40AE-ACD2-4460D584EA35</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/canadianshield-private-tls.mobileconfig
+++ b/canadianshield-private-tls.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>TLS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>2620:10A:80BB::10</string>
+					<string>2620:10A:80BC::10</string>
+					<string>149.112.121.10</string>
+					<string>149.112.122.10</string>
+				</array>
+				<key>ServerName</key>
+				<string>private.canadianshield.cira.ca</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use Canadian Shield Encrypted DNS over TLS</string>
+			<key>PayloadDisplayName</key>
+			<string>Canadian Shield DNS over TLS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the Canadian Shield DNS to Big Sur and iOS 14 based systems</string>
+	<key>PayloadDisplayName</key>
+	<string>Canadian Shield DNS over TLS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>32E01895-86AB-40AE-ACD2-4460D584EA35</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/canadianshield-protected-https.mobileconfig
+++ b/canadianshield-protected-https.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>2620:10A:80BB::10</string>
+					<string>2620:10A:80BC::10</string>
+					<string>149.112.121.10</string>
+					<string>149.112.122.10</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://protected.canadianshield.cira.ca/dns-query</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use Canadian Shield Encrypted DNS over HTTPS</string>
+			<key>PayloadDisplayName</key>
+			<string>Canadian Shield DNS over HTTPS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the Canadian Shield DNS to Big Sur and iOS 14 based systems</string>
+	<key>PayloadDisplayName</key>
+	<string>Canadian Shield DNS over HTTPS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>32E01895-86AB-40AE-ACD2-4460D584EA35</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/canadianshield-protected-tls.mobileconfig
+++ b/canadianshield-protected-tls.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>TLS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>2620:10A:80BB::20</string>
+					<string>2620:10A:80BC::20</string>
+					<string>149.112.121.20</string>
+					<string>149.112.122.20</string>
+				</array>
+				<key>ServerName</key>
+				<string>protected.canadianshield.cira.ca</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use Canadian Shield Encrypted DNS over TLS</string>
+			<key>PayloadDisplayName</key>
+			<string>Canadian Shield DNS over TLS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the Canadian Shield DNS to Big Sur and iOS 14 based systems</string>
+	<key>PayloadDisplayName</key>
+	<string>Canadian Shield DNS over TLS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>32E01895-86AB-40AE-ACD2-4460D584EA35</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Adds CIRA's Canadian Shield service: https://www.cira.ca/cybersecurity-services/canadian-shield

I also amended Quad9's description since the filtered addresses are being used.