### PR TITLE
add ServerAddresses for 360 Public Security DNS

### DIFF
--- a/profiles/360-https.mobileconfig
+++ b/profiles/360-https.mobileconfig
@@ -11,8 +11,8 @@
 				<string>HTTPS</string>
 				<key>ServerAddresses</key>
 				<array>
-					<string>101.198.198.198</string>
-					<string>101.198.199.200</string>
+					<string>101.226.4.6</string>
+					<string>218.30.118.6</string>
 				</array>
 				<key>ServerURL</key>
 				<string>https://doh.360.cn/dns-query</string>

--- a/profiles/360-https.mobileconfig
+++ b/profiles/360-https.mobileconfig
@@ -9,6 +9,11 @@
 			<dict>
 				<key>DNSProtocol</key>
 				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>101.198.198.198</string>
+					<string>101.198.199.200</string>
+				</array>
 				<key>ServerURL</key>
 				<string>https://doh.360.cn/dns-query</string>
 			</dict>


### PR DESCRIPTION
add ServerAddresses for 360 Public Security DNS

IP address comes from the customer server at https://sdns.360.net/dnsPublic.html#course
tested by installing the profile on MacBook and opening websites using Safari.

#126 