### PR TITLE
Add DNS4EU resolver

### DIFF
--- a/profiles/dns4eu-protective-adblock.mobileconfig
+++ b/profiles/dns4eu-protective-adblock.mobileconfig
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>86.54.11.13</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://www.joindns4.eu/for-public</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use DNS4EU Protective + Adblock DNS</string>
+			<key>PayloadDisplayName</key>
+			<string>DNS4EU Protective + Adblock DNS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.C70B0454-39E1-4E0D-9B4D-F09A1BBD981C</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>C70B0454-39E1-4E0D-9B4D-F09A1BBD981C</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the DNS4EU Protective + Adblock DNS</string>
+	<key>PayloadDisplayName</key>
+	<string>DNS4EU Protective + Adblock DNS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>C70B0454-39E1-4E0D-9B4D-F09A1BBD981C</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/profiles/dns4eu-protective-child-adblock.mobileconfig
+++ b/profiles/dns4eu-protective-child-adblock.mobileconfig
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>86.54.11.11</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://www.joindns4.eu/for-public</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use DNS4EU Protective + Child Protection + Adblock DNS</string>
+			<key>PayloadDisplayName</key>
+			<string>DNS4EU Protective + Child Protection + Adblock DNS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.FA548D63-5783-458C-9797-55EDFC9B326F</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>FA548D63-5783-458C-9797-55EDFC9B326F</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the DNS4EU Protective + Child Protection + Adblock DNS</string>
+	<key>PayloadDisplayName</key>
+	<string>DNS4EU Protective + Child Protection + Adblock DNS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>FA548D63-5783-458C-9797-55EDFC9B326F</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/profiles/dns4eu-protective-child.mobileconfig
+++ b/profiles/dns4eu-protective-child.mobileconfig
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>86.54.11.12</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://www.joindns4.eu/for-public</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use DNS4EU Protective + Child Protection DNS</string>
+			<key>PayloadDisplayName</key>
+			<string>DNS4EU Protective + Child Protection DNS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.0374E961-CB4F-4339-AB0E-4D52671FB227</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>0374E961-CB4F-4339-AB0E-4D52671FB227</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the DNS4EU Protective + Child Protection DNS</string>
+	<key>PayloadDisplayName</key>
+	<string>DNS4EU Protective + Child Protection DNS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>0374E961-CB4F-4339-AB0E-4D52671FB227</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/profiles/dns4eu-protective.mobileconfig
+++ b/profiles/dns4eu-protective.mobileconfig
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>86.54.11.1</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://www.joindns4.eu/for-public</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use DNS4EU Protective DNS</string>
+			<key>PayloadDisplayName</key>
+			<string>DNS4EU Protective DNS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.0FA9EA39-A0AC-4928-BDD3-3664285BA74D</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>0FA9EA39-A0AC-4928-BDD3-3664285BA74D</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the DNS4EU Protective DNS</string>
+	<key>PayloadDisplayName</key>
+	<string>DNS4EU Protective DNS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>0FA9EA39-A0AC-4928-BDD3-3664285BA74D</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/profiles/dns4eu-unfiltered.mobileconfig
+++ b/profiles/dns4eu-unfiltered.mobileconfig
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>HTTPS</string>
+				<key>ServerAddresses</key>
+				<array>
+					<string>86.54.11.100</string>
+				</array>
+				<key>ServerURL</key>
+				<string>https://www.joindns4.eu/for-public</string>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures device to use DNS4EU Unfiltered DNS</string>
+			<key>PayloadDisplayName</key>
+			<string>DNS4EU Unfiltered DNS</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.12CCB1B6-7D9C-4F18-BB48-D37BAEF69B83</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>12CCB1B6-7D9C-4F18-BB48-D37BAEF69B83</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ProhibitDisablement</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Adds the DNS4EU Unfiltered DNS</string>
+	<key>PayloadDisplayName</key>
+	<string>DNS4EU Unfiltered DNS</string>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>12CCB1B6-7D9C-4F18-BB48-D37BAEF69B83</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Hi there!
Thanks for these profiles 🙂 
This changeset adds profiles for all public offers of https://www.joindns4.eu/for-public.
After creating the UUID as per README instructions, I set the same UUID for the different `PayloadUUID` and `PayloadIdentifier`. They didn't match in some of the other profiles, but I didn't know if I should generate new ones for all three instances. Please let me know if all three need to be different.
I tested two of these profiles on iOS and they installed properly.
Have a good day! 😊 