### PR TITLE
Add PayloadScope to generate script and generate profiles.

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -234,6 +234,8 @@ ${x.ServerAddresses.map((i) => `\t\t\t\t\t<string>${i}</string>`).join('\n')}
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/360-https.mobileconfig
+++ b/profiles/360-https.mobileconfig
@@ -11,8 +11,8 @@
 				<string>HTTPS</string>
 				<key>ServerAddresses</key>
 				<array>
-					<string>101.226.4.6</string>
-					<string>218.30.118.6</string>
+					<string>101.198.198.198</string>
+					<string>101.198.199.200</string>
 				</array>
 				<key>ServerURL</key>
 				<string>https://doh.360.cn/dns-query</string>
@@ -41,6 +41,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/adguard-default-https.mobileconfig
+++ b/profiles/adguard-default-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/adguard-default-tls.mobileconfig
+++ b/profiles/adguard-default-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/adguard-family-https.mobileconfig
+++ b/profiles/adguard-family-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/adguard-family-tls.mobileconfig
+++ b/profiles/adguard-family-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/adguard-nofilter-https.mobileconfig
+++ b/profiles/adguard-nofilter-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/adguard-nofilter-tls.mobileconfig
+++ b/profiles/adguard-nofilter-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/alibaba-https.mobileconfig
+++ b/profiles/alibaba-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/alibaba-tls.mobileconfig
+++ b/profiles/alibaba-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/canadianshield-family-https.mobileconfig
+++ b/profiles/canadianshield-family-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/canadianshield-family-tls.mobileconfig
+++ b/profiles/canadianshield-family-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/canadianshield-private-https.mobileconfig
+++ b/profiles/canadianshield-private-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/canadianshield-private-tls.mobileconfig
+++ b/profiles/canadianshield-private-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/canadianshield-protected-https.mobileconfig
+++ b/profiles/canadianshield-protected-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/canadianshield-protected-tls.mobileconfig
+++ b/profiles/canadianshield-protected-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cleanbrowsing-adult-https.mobileconfig
+++ b/profiles/cleanbrowsing-adult-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cleanbrowsing-adult-tls.mobileconfig
+++ b/profiles/cleanbrowsing-adult-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cleanbrowsing-family-https.mobileconfig
+++ b/profiles/cleanbrowsing-family-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cleanbrowsing-family-tls.mobileconfig
+++ b/profiles/cleanbrowsing-family-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cleanbrowsing-security-https.mobileconfig
+++ b/profiles/cleanbrowsing-security-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cleanbrowsing-security-tls.mobileconfig
+++ b/profiles/cleanbrowsing-security-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cloudflare-family-https.mobileconfig
+++ b/profiles/cloudflare-family-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cloudflare-https.mobileconfig
+++ b/profiles/cloudflare-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cloudflare-malware-https.mobileconfig
+++ b/profiles/cloudflare-malware-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/cloudflare-tls.mobileconfig
+++ b/profiles/cloudflare-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-https.mobileconfig
+++ b/profiles/dns4eu-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-malware-https.mobileconfig
+++ b/profiles/dns4eu-malware-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-malware-tls.mobileconfig
+++ b/profiles/dns4eu-malware-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-protective-ads-https.mobileconfig
+++ b/profiles/dns4eu-protective-ads-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-protective-ads-tls.mobileconfig
+++ b/profiles/dns4eu-protective-ads-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-protective-child-ads-https.mobileconfig
+++ b/profiles/dns4eu-protective-child-ads-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-protective-child-ads-tls.mobileconfig
+++ b/profiles/dns4eu-protective-child-ads-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-protective-child-https.mobileconfig
+++ b/profiles/dns4eu-protective-child-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-protective-child-tls.mobileconfig
+++ b/profiles/dns4eu-protective-child-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dns4eu-tls.mobileconfig
+++ b/profiles/dns4eu-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dnspod-https.mobileconfig
+++ b/profiles/dnspod-https.mobileconfig
@@ -41,6 +41,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/dnspod-tls.mobileconfig
+++ b/profiles/dnspod-tls.mobileconfig
@@ -41,6 +41,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/fdn-https.mobileconfig
+++ b/profiles/fdn-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/fdn-tls.mobileconfig
+++ b/profiles/fdn-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/ffmucdns-https.mobileconfig
+++ b/profiles/ffmucdns-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/ffmucdns-tls.mobileconfig
+++ b/profiles/ffmucdns-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/google-https.mobileconfig
+++ b/profiles/google-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/google-tls.mobileconfig
+++ b/profiles/google-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/mullvad-adblock-doh.mobileconfig
+++ b/profiles/mullvad-adblock-doh.mobileconfig
@@ -41,6 +41,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/mullvad-doh.mobileconfig
+++ b/profiles/mullvad-doh.mobileconfig
@@ -41,6 +41,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/quad9-ECS-https.mobileconfig
+++ b/profiles/quad9-ECS-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/quad9-ECS-tls.mobileconfig
+++ b/profiles/quad9-ECS-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/quad9-https.mobileconfig
+++ b/profiles/quad9-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/quad9-nofilter-https.mobileconfig
+++ b/profiles/quad9-nofilter-https.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/quad9-nofilter-tls.mobileconfig
+++ b/profiles/quad9-nofilter-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>

--- a/profiles/quad9-tls.mobileconfig
+++ b/profiles/quad9-tls.mobileconfig
@@ -43,6 +43,8 @@
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>


### PR DESCRIPTION
**Description**
macOS 26.1 introduces stricter validation for network-related configuration profiles.
Profiles that include DNS / VPN / Network Extension payloads now require an explicit PayloadScope to be set.
Previously, Cloudflare security profiles without PayloadScope could still be installed successfully.
Starting with macOS 26.1, such profiles fail to install with errors like “The VPN service payload could not be installed”.

**This PR adds:**
```
<key>PayloadScope</key>
<string>System</string>
```
to all profiles, explicitly declaring them as system-scoped profiles, which restores compatibility with macOS 26.1 and later.
This change aligns with recent fixes adopted by other DNS providers (e.g. NextDNS, ControlD) and reflects Apple’s updated security requirements for system-level network configuration.