### PR TITLE
docs: add link to auto-signed fork for users needing automated updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ they will have a verified check box on the installation screen. It also ensures 
 The signature is valid until `2025-11-02`
 
 Previous signatures by:
+
 [@Xernium](https://github.com/Xernium), replaced at `2024-11-01`
 
 [@Candygoblen123](https://github.com/Candygoblen123), replaced at `2023-11-29`
@@ -104,6 +105,12 @@ Previous signatures by:
 [comment]: <> (We recommend that you install a signed profile instead of an unsigned profile because it ensures that it was not modified while it was downloading.)
 
 To verify resolver IPs and hostnames, compare mobileconfig files to their documentation URLs. Internal workings of the profiles are described on [developer.apple.com](https://developer.apple.com/documentation/devicemanagement/dnssettings). In order to verify signed mobileconfigs, you will need to download them to your computer and open them in a text editor, because signing profiles makes GitHub think that they are binary files.
+
+> **🚀 Automated Alternative:**
+>
+> If you encounter "Not Verified" warnings or need the absolute latest updates, check out the **auto-signed fork** by [@jiya-mira](https://github.com/jiya-mira/encrypted-dns).
+>
+> This fork implements a **zero-touch automation workflow** that regenerates and signs all profiles daily, ensuring certificates remain valid and synchronized with upstream changes.
 
 ## On demand activation
 


### PR DESCRIPTION
Hi Paul (@paulmillr),

I've noticed in the issues that users occasionally face challenges with expired certificates or "Not Verified" warnings, given the manual nature of the signing process.

I have created a fork that implements a **fully automated signing pipeline** (using Python/uv) which keeps the profiles in the `signed/` directory up-to-date automatically.

I've added a small note in the `Signed Profiles` section pointing users to this automated alternative. This might help reduce the maintenance burden of manually re-signing profiles and provide a fallback for users when the main certificates expire.

Thanks for maintaining this awesome list of providers!